### PR TITLE
Filled out 2-one-of for [1] keyword type conversions (5.4.1.1-6)

### DIFF
--- a/src/main/ast/type.c
+++ b/src/main/ast/type.c
@@ -241,49 +241,71 @@ bool typeImplicitlyConvertable(Type const *from, Type const *to) {
     // float     | -yes-- | n | ------yes------ | no | ---yes---- | --no--
     // double    | -yes-- | n | ------yes------ | no | -----yes------ | n
     // bool      | ------------------------no------------------------ | y
-    switch (to->kind) {
+    switch (to->data.keyword.keyword) {
       case TK_UBYTE:
-        return from->kind == TK_UBYTE;
+        return from->data.keyword.keyword == TK_UBYTE;
       case TK_BYTE:
-        return from->kind == TK_BYTE;
+        return from->data.keyword.keyword == TK_BYTE;
       case TK_CHAR:
-        return from->kind == TK_CHAR;
+        return from->data.keyword.keyword == TK_CHAR;
       case TK_USHORT:
-        return from->kind == TK_UBYTE || from->kind == TK_USHORT;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_USHORT;
       case TK_SHORT:
-        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
-               from->kind == TK_SHORT;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_BYTE ||
+               from->data.keyword.keyword == TK_SHORT;
       case TK_UINT:
-        return from->kind == TK_UBYTE || from->kind == TK_USHORT ||
-               from->kind == TK_UINT;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_USHORT ||
+               from->data.keyword.keyword == TK_UINT;
       case TK_INT:
-        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
-               from->kind == TK_USHORT || from->kind == TK_SHORT ||
-               from->kind == TK_UINT;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_BYTE ||
+               from->data.keyword.keyword == TK_USHORT ||
+               from->data.keyword.keyword == TK_SHORT ||
+               from->data.keyword.keyword == TK_UINT;
       case TK_WCHAR:
-        return from->kind == TK_CHAR || from->kind == TK_WCHAR;
+        return from->data.keyword.keyword == TK_CHAR ||
+               from->data.keyword.keyword == TK_WCHAR;
       case TK_ULONG:
-        return from->kind == TK_UBYTE || from->kind == TK_USHORT ||
-               from->kind == TK_UINT || from->kind == TK_ULONG;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_USHORT ||
+               from->data.keyword.keyword == TK_UINT ||
+               from->data.keyword.keyword == TK_ULONG;
       case TK_LONG:
-        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
-               from->kind == TK_USHORT || from->kind == TK_SHORT ||
-               from->kind == TK_UINT || from->kind == TK_INT ||
-               from->kind == TK_LONG;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_BYTE ||
+               from->data.keyword.keyword == TK_USHORT ||
+               from->data.keyword.keyword == TK_SHORT ||
+               from->data.keyword.keyword == TK_UINT ||
+               from->data.keyword.keyword == TK_INT ||
+               from->data.keyword.keyword == TK_LONG;
       case TK_FLOAT:
-        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
-               from->kind == TK_USHORT || from->kind == TK_SHORT ||
-               from->kind == TK_UINT || from->kind == TK_INT ||
-               from->kind == TK_ULONG || from->kind == TK_LONG ||
-               from->kind == TK_FLOAT;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_BYTE ||
+               from->data.keyword.keyword == TK_USHORT ||
+               from->data.keyword.keyword == TK_SHORT ||
+               from->data.keyword.keyword == TK_UINT ||
+               from->data.keyword.keyword == TK_INT ||
+               from->data.keyword.keyword == TK_ULONG ||
+               from->data.keyword.keyword == TK_LONG ||
+               from->data.keyword.keyword == TK_FLOAT;
       case TK_DOUBLE:
-        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
-               from->kind == TK_USHORT || from->kind == TK_SHORT ||
-               from->kind == TK_UINT || from->kind == TK_INT ||
-               from->kind == TK_ULONG || from->kind == TK_LONG ||
-               from->kind == TK_FLOAT || from->kind == TK_DOUBLE;
+        return from->data.keyword.keyword == TK_UBYTE ||
+               from->data.keyword.keyword == TK_BYTE ||
+               from->data.keyword.keyword == TK_USHORT ||
+               from->data.keyword.keyword == TK_SHORT ||
+               from->data.keyword.keyword == TK_UINT ||
+               from->data.keyword.keyword == TK_INT ||
+               from->data.keyword.keyword == TK_ULONG ||
+               from->data.keyword.keyword == TK_LONG ||
+               from->data.keyword.keyword == TK_FLOAT ||
+               from->data.keyword.keyword == TK_DOUBLE;
       case TK_BOOL:
-        return from->kind == TK_DOUBLE;
+        return from->data.keyword.keyword == TK_DOUBLE;
+      default:
+        error(__FILE__, __LINE__, "invalid keyword type encountered");
     }
     return false;
   } else if (from->kind == TK_POINTER && to->kind == TK_POINTER) {

--- a/src/main/ast/type.c
+++ b/src/main/ast/type.c
@@ -241,7 +241,7 @@ bool typeImplicitlyConvertable(Type const *from, Type const *to) {
     // float     | -yes-- | n | ------yes------ | no | ---yes---- | --no--
     // double    | -yes-- | n | ------yes------ | no | -----yes------ | n
     // bool      | ------------------------no------------------------ | y
-    switch(to->kind){
+    switch (to->kind) {
       case TK_UBYTE:
         return from->kind == TK_UBYTE;
       case TK_BYTE:
@@ -249,59 +249,39 @@ bool typeImplicitlyConvertable(Type const *from, Type const *to) {
       case TK_CHAR:
         return from->kind == TK_CHAR;
       case TK_USHORT:
-        return from->kind == TK_UBYTE  || 
-               from->kind == TK_USHORT;
+        return from->kind == TK_UBYTE || from->kind == TK_USHORT;
       case TK_SHORT:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_BYTE   ||
+        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
                from->kind == TK_SHORT;
       case TK_UINT:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_USHORT ||
+        return from->kind == TK_UBYTE || from->kind == TK_USHORT ||
                from->kind == TK_UINT;
       case TK_INT:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_BYTE   ||
-               from->kind == TK_USHORT ||
-               from->kind == TK_SHORT  ||
+        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
+               from->kind == TK_USHORT || from->kind == TK_SHORT ||
                from->kind == TK_UINT;
       case TK_WCHAR:
-        return from->kind == TK_CHAR   ||
-               from->kind == TK_WCHAR;
+        return from->kind == TK_CHAR || from->kind == TK_WCHAR;
       case TK_ULONG:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_USHORT ||
-               from->kind == TK_UINT   ||
-               from->kind == TK_ULONG;
+        return from->kind == TK_UBYTE || from->kind == TK_USHORT ||
+               from->kind == TK_UINT || from->kind == TK_ULONG;
       case TK_LONG:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_BYTE   ||
-               from->kind == TK_USHORT ||
-               from->kind == TK_SHORT  ||
-               from->kind == TK_UINT   ||
-               from->kind == TK_INT    ||
+        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
+               from->kind == TK_USHORT || from->kind == TK_SHORT ||
+               from->kind == TK_UINT || from->kind == TK_INT ||
                from->kind == TK_LONG;
       case TK_FLOAT:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_BYTE   ||
-               from->kind == TK_USHORT ||
-               from->kind == TK_SHORT  ||
-               from->kind == TK_UINT   ||
-               from->kind == TK_INT    ||
-               from->kind == TK_ULONG  ||
-               from->kind == TK_LONG   ||
+        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
+               from->kind == TK_USHORT || from->kind == TK_SHORT ||
+               from->kind == TK_UINT || from->kind == TK_INT ||
+               from->kind == TK_ULONG || from->kind == TK_LONG ||
                from->kind == TK_FLOAT;
       case TK_DOUBLE:
-        return from->kind == TK_UBYTE  ||
-               from->kind == TK_BYTE   ||
-               from->kind == TK_USHORT ||
-               from->kind == TK_SHORT  ||
-               from->kind == TK_UINT   ||
-               from->kind == TK_INT    ||
-               from->kind == TK_ULONG  ||
-               from->kind == TK_LONG   ||
-               from->kind == TK_FLOAT  ||
-               from->kind == TK_DOUBLE;
+        return from->kind == TK_UBYTE || from->kind == TK_BYTE ||
+               from->kind == TK_USHORT || from->kind == TK_SHORT ||
+               from->kind == TK_UINT || from->kind == TK_INT ||
+               from->kind == TK_ULONG || from->kind == TK_LONG ||
+               from->kind == TK_FLOAT || from->kind == TK_DOUBLE;
       case TK_BOOL:
         return from->kind == TK_DOUBLE;
     }

--- a/src/main/ast/type.c
+++ b/src/main/ast/type.c
@@ -198,7 +198,71 @@ bool typeImplicitlyConvertable(Type const *from, Type const *to) {
     // float     | -yes-- | n | ------yes------ | no | ---yes---- | --no--
     // double    | -yes-- | n | ------yes------ | no | -----yes------ | n
     // bool      | ------------------------no------------------------ | y
-    return false;  // TODO
+    switch(to->kind){
+      case TK_UBYTE:
+        return from->kind == TK_UBYTE;
+      case TK_BYTE:
+        return from->kind == TK_BYTE;
+      case TK_CHAR:
+        return from->kind == TK_CHAR;
+      case TK_USHORT:
+        return from->kind == TK_UBYTE  || 
+               from->kind == TK_USHORT;
+      case TK_SHORT:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_BYTE   ||
+               from->kind == TK_SHORT;
+      case TK_UINT:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_USHORT ||
+               from->kind == TK_UINT;
+      case TK_INT:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_BYTE   ||
+               from->kind == TK_USHORT ||
+               from->kind == TK_SHORT  ||
+               from->kind == TK_UINT;
+      case TK_WCHAR:
+        return from->kind == TK_CHAR   ||
+               from->kind == TK_WCHAR;
+      case TK_ULONG:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_USHORT ||
+               from->kind == TK_UINT   ||
+               from->kind == TK_ULONG;
+      case TK_LONG:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_BYTE   ||
+               from->kind == TK_USHORT ||
+               from->kind == TK_SHORT  ||
+               from->kind == TK_UINT   ||
+               from->kind == TK_INT    ||
+               from->kind == TK_LONG;
+      case TK_FLOAT:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_BYTE   ||
+               from->kind == TK_USHORT ||
+               from->kind == TK_SHORT  ||
+               from->kind == TK_UINT   ||
+               from->kind == TK_INT    ||
+               from->kind == TK_ULONG  ||
+               from->kind == TK_LONG   ||
+               from->kind == TK_FLOAT;
+      case TK_DOUBLE:
+        return from->kind == TK_UBYTE  ||
+               from->kind == TK_BYTE   ||
+               from->kind == TK_USHORT ||
+               from->kind == TK_SHORT  ||
+               from->kind == TK_UINT   ||
+               from->kind == TK_INT    ||
+               from->kind == TK_ULONG  ||
+               from->kind == TK_LONG   ||
+               from->kind == TK_FLOAT  ||
+               from->kind == TK_DOUBLE;
+      case TK_BOOL:
+        return from->kind == TK_DOUBLE;
+    }
+    return false;
   } else if (from->kind == TK_POINTER && to->kind == TK_POINTER) {
     // [2]: pointer type conversion (5.4.1.9) =
     //            at least as CV-qualified && (

--- a/src/main/ast/type.c
+++ b/src/main/ast/type.c
@@ -284,8 +284,9 @@ bool typeImplicitlyConvertable(Type const *from, Type const *to) {
                from->kind == TK_FLOAT || from->kind == TK_DOUBLE;
       case TK_BOOL:
         return from->kind == TK_DOUBLE;
+      default:
+        error(__FILE__, __LINE__, "invalid keyword type encountered");
     }
-    return false;
   } else if (from->kind == TK_POINTER && to->kind == TK_POINTER) {
     return pointerBaseImplicitlyConvertable(from->data.pointer.base,
                                             to->data.pointer.base);


### PR DESCRIPTION
---
name: Pull request
about: Contribute to the repository
title: 'Filled out 2-one-of for [1] keyword type conversions (5.4.1.1-6)'
assignees: JustinHuPrime

---

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
What the title says

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was asked to do this

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I didn't do any testing

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have run clang-format to make sure that it does.
- [ ] My code passes all of the tests.
- [ ] I have added tests to cover any new features added.
- [ ] I have updated the documentation to reflect the current state of the repo.
- [x] I have removed or updated comments that are no longer relevant, wherever I saw them.
- [x] I am aware that I am releasing my code under the GPL Version 3 or later.
- [x] I agree to the Developer Certificate of Origin (<https://developercertificate.org/>).
