### PR TITLE
Allow leading zeros in numeric literals

### DIFF
--- a/src/main/lexer/lexer.c
+++ b/src/main/lexer/lexer.c
@@ -565,7 +565,8 @@ static void lexNumber(FileListEntry *entry, Token *token) {
       case 'b': {
         // [+-]0b
         // is binary, remove leading zeros and lex it
-        while ((next = get(state)) == '0');
+        while ((next = get(state)) == '0')
+          ;
         put(state, 1);
         lexBinary(entry, token, start);
         return;
@@ -573,7 +574,8 @@ static void lexNumber(FileListEntry *entry, Token *token) {
       case 'x': {
         // [+-]0x
         // is hex, remove leading zeros and lex it
-        while ((next = get(state)) == '0');
+        while ((next = get(state)) == '0')
+          ;
         put(state, 1);
         lexHex(entry, token, start);
         return;
@@ -581,7 +583,8 @@ static void lexNumber(FileListEntry *entry, Token *token) {
       case 'o': {
         // [+-]0o
         // is octal, remove leading zeros and lex it
-        while ((next = get(state)) == '0');
+        while ((next = get(state)) == '0')
+          ;
         put(state, 1);
         lexOctal(entry, token, start);
         return;
@@ -592,7 +595,8 @@ static void lexNumber(FileListEntry *entry, Token *token) {
         // drop leading zeros
         if (second == '0') {
           // if [+-]00 then remove leading 0's
-          while ((next = get(state)) == '0');
+          while ((next = get(state)) == '0')
+            ;
         } else {
           next = second;
         }

--- a/src/main/lexer/lexer.c
+++ b/src/main/lexer/lexer.c
@@ -559,38 +559,59 @@ static void lexNumber(FileListEntry *entry, Token *token) {
 
   if (next == '0') {
     // [+-]0
-    // maybe hex, dec (float), oct, bin, or zero
+    // maybe decimal, hex, dec (float), oct, bin, or zero
     char second = get(state);
     switch (second) {
       case 'b': {
         // [+-]0b
-        // is binary, lex it
+        // is binary, remove leading zeros and lex it
+        while ((next = get(state)) == '0');
+        put(state, 1);
         lexBinary(entry, token, start);
         return;
       }
       case 'x': {
         // [+-]0x
-        // is hex, lex it
+        // is hex, remove leading zeros and lex it
+        while ((next = get(state)) == '0');
+        put(state, 1);
         lexHex(entry, token, start);
         return;
       }
       case 'o': {
         // [+-]0o
-        // is octal, lex it
+        // is octal, remove leading zeros and lex it
+        while ((next = get(state)) == '0');
+        put(state, 1);
         lexOctal(entry, token, start);
         return;
       }
       default: {
-        if (second == '.') {
-          // [+-]0.
-          // is a decimal, return the dot and the zero, and lex it
+        // [+-]0[^bxo]
+        // either zero or decimal literal with leading 0's
+        // drop leading zeros
+        if (second == '0') {
+          // if [+-]00 then remove leading 0's
+          while ((next = get(state)) == '0');
+        } else {
+          next = second;
+        }
+        if (next == '.') {
+          // [+-]0+[0-9].
+          // is floating point literal, lex it
           put(state, 2);
           lexDecimal(entry, token, start);
           return;
-        } else {
-          // just a zero - [+-]0
+        } else if (next >= '1' && next <= '9') {
+          // [+-]0+[1-9]
+          // is non-zero decimal literal, lex it
           put(state, 1);
-          clip(state, token, start, TT_LIT_INT_0);
+          lexDecimal(entry, token, start);
+          return;
+        } else {
+          // just a zero - [+-]0+
+          put(state, 1);
+          clip(state, token, start, TT_LIT_INT_D);
           return;
         }
       }

--- a/src/main/lexer/lexer.h
+++ b/src/main/lexer/lexer.h
@@ -141,7 +141,6 @@ typedef enum {
   TT_LIT_WSTRING,
   TT_LIT_CHAR,
   TT_LIT_WCHAR,
-  TT_LIT_INT_0,
   TT_LIT_INT_B,
   TT_LIT_INT_O,
   TT_LIT_INT_D,

--- a/src/main/parser/functionBody.c
+++ b/src/main/parser/functionBody.c
@@ -412,7 +412,6 @@ static Node *parseExtendedIntLiteral(FileListEntry *entry, Node *unparsed,
       if (n == NULL) errorIntOverflow(entry, &peek);
       return n;
     }
-    case TT_LIT_INT_0:
     case TT_LIT_INT_D: {
       int8_t sign;
       uint64_t magnitude;
@@ -503,7 +502,6 @@ static Node *parseAggregateInitializer(FileListEntry *entry, Node *unparsed,
       case TT_LIT_WSTRING:
       case TT_LIT_CHAR:
       case TT_LIT_WCHAR:
-      case TT_LIT_INT_0:
       case TT_LIT_INT_B:
       case TT_LIT_INT_O:
       case TT_LIT_INT_D:
@@ -584,7 +582,6 @@ static Node *parseLiteral(FileListEntry *entry, Node *unparsed,
     case TT_LIT_WCHAR:
     case TT_LIT_INT_B:
     case TT_LIT_INT_O:
-    case TT_LIT_INT_0:
     case TT_LIT_INT_D:
     case TT_LIT_INT_H:
     case TT_ID: {
@@ -983,7 +980,6 @@ static Node *parsePrimaryExpression(FileListEntry *entry, Node *unparsed,
       case TT_LIT_WSTRING:
       case TT_LIT_CHAR:
       case TT_LIT_WCHAR:
-      case TT_LIT_INT_0:
       case TT_LIT_INT_B:
       case TT_LIT_INT_O:
       case TT_LIT_INT_D:
@@ -1187,7 +1183,6 @@ static Node *parsePrimaryExpression(FileListEntry *entry, Node *unparsed,
           case TT_CAST:
           case TT_SIZEOF:
           case TT_LPAREN:
-          case TT_LIT_INT_0:
           case TT_LIT_INT_B:
           case TT_BAD_BIN:
           case TT_LIT_INT_O:
@@ -2236,7 +2231,6 @@ static Node *parseForInitStmt(FileListEntry *entry, Node *unparsed,
     case TT_CAST:
     case TT_SIZEOF:
     case TT_LPAREN:
-    case TT_LIT_INT_0:
     case TT_LIT_INT_B:
     case TT_BAD_BIN:
     case TT_LIT_INT_O:
@@ -3385,7 +3379,6 @@ static Node *parseStmt(FileListEntry *entry, Node *unparsed, Environment *env) {
     case TT_SIZEOF:
     case TT_LPAREN:
     case TT_LSQUARE:
-    case TT_LIT_INT_0:
     case TT_LIT_INT_B:
     case TT_BAD_BIN:
     case TT_LIT_INT_O:

--- a/src/main/parser/topLevel.c
+++ b/src/main/parser/topLevel.c
@@ -307,7 +307,6 @@ static Node *parseExtendedIntLiteral(FileListEntry *entry) {
       if (n == NULL) errorIntOverflow(entry, &peek);
       return n;
     }
-    case TT_LIT_INT_0:
     case TT_LIT_INT_D: {
       int8_t sign;
       uint64_t magnitude;
@@ -375,7 +374,6 @@ static Node *parseAggregateInitializer(FileListEntry *entry, Token *start) {
       case TT_LIT_WSTRING:
       case TT_LIT_CHAR:
       case TT_LIT_WCHAR:
-      case TT_LIT_INT_0:
       case TT_LIT_INT_B:
       case TT_LIT_INT_O:
       case TT_LIT_INT_D:
@@ -456,7 +454,6 @@ static Node *parseLiteral(FileListEntry *entry) {
     case TT_LIT_WCHAR:
     case TT_LIT_INT_B:
     case TT_LIT_INT_O:
-    case TT_LIT_INT_0:
     case TT_LIT_INT_D:
     case TT_LIT_INT_H:
     case TT_ID: {

--- a/src/test/tests/lexer.c
+++ b/src/test/tests/lexer.c
@@ -156,7 +156,7 @@ static void testAllTokens(void) {
       {TT_LIT_INT_B, 10, 71, "0b1"},
       {TT_LIT_INT_O, 10, 74, "+0o377"},
 
-      {TT_LIT_INT_0, 14, 1, "0"},
+      {TT_LIT_INT_D, 14, 1, "0"},
       {TT_LIT_DOUBLE, 14, 3, "1.1"},
       {TT_LIT_FLOAT, 14, 6, "+1.1f"},
 

--- a/standard/Appendix A - Lexicon.ebnf
+++ b/standard/Appendix A - Lexicon.ebnf
@@ -47,11 +47,10 @@ magic_token = "__FILE__"
             | "__VERSION__"
 ;
 
-int_literal = [ "-" | "+" ], ( nonzero_digit, { digit }
+int_literal = [ "-" | "+" ], ( { digit }
                              | "0x", hex_digit, { hex_digit }
                              | "0b", binary_digit, { binary_digit }
                              | "0o", octal_digit, { octal_digit }
-                             | "0"
                              )
 ;
 double_literal = [ "-" | "+" ], digit, { digit }, ".", digit, { digit } ;
@@ -64,10 +63,7 @@ wchar_literal = "'", ( alphabetic | digit | symbol | escaped | tab | escaped_wch
 alphabetic = ? any ASCII alphabetic character ?
            | ? any implementation-defined alphabetic characters ?
 ;
-nonzero_digit = "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
-digit = "0"
-      | nonzero_digit
-;
+digit =  "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 symbol = ? any ASCII symbol plus space ?
        | ? any implementation-defined symbols or spaces ?
 ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some changes to the grammar of the language and appropriate parts of the lexer to allow for numeric literals to have leading zeros. Previously, a numeric literal such as `001` would have been disallowed due to conflict with the syntax for octal literals, but this is now allowable due to a change made to the syntax for octal literals.

To effect this change, whenever a numeric literal is lexed which begins with a `0` after any relevant prefix (such as `0x`), these zeros are dropped before the literal is passed on to the appropriate lexing function. This also allows for the `TT_LIT_INT_0` token to be removed, since the lexing of zeros is now merged with the lexing of all other decimal literals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows for leading zeros in literals of all types, which is frequently desirable for aligning numeric literals in source code for legibility reasons.

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All current tests pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have run clang-format to make sure that it does.
- [x] My code passes all of the tests.
- [x] I have added tests to cover any new features added.
- [x] I have updated the documentation to reflect the current state of the repo.
- [x] I have removed or updated comments that are no longer relevant, wherever I saw them.
- [x] This included updating the copyright header.
- [x] I am aware that I am releasing my code under the GPL Version 3 or later.
- [x] I agree to the Developer Certificate of Origin (<https://developercertificate.org/>).
